### PR TITLE
User can see map displaying specific markers of trail while on specific trail page

### DIFF
--- a/cypress/fixtures/user_can_view_specific_trail.json
+++ b/cypress/fixtures/user_can_view_specific_trail.json
@@ -7,5 +7,7 @@
   "location": "Åland",
   "continent": "Europe",
   "duration": "5",
-  "intensity": "1"
+  "intensity": "1",
+  "latitude": 53.0032,
+  "longitude": 14.3435
 }

--- a/cypress/integration/userCanViewSpecificTrail.spec.js
+++ b/cypress/integration/userCanViewSpecificTrail.spec.js
@@ -6,6 +6,7 @@ describe('User can view a specific trail', () => {
       response: 'fixture:user_can_view_specific_trail.json',
       status: 200
     })
+    
     cy.get('#trail-list')
       .within(() => {
         cy.get('#card_1').click()
@@ -20,6 +21,7 @@ describe('User can view a specific trail', () => {
         cy.get('#duration_1').should('contain', '5')
         cy.get('#intensity_1').should('contain', '1')
       })
+    cy.get('[title="Åland lazy trail"]').should('exist')
   })
 
   it('unsuccessfully', () => {

--- a/src/Components/SpecificTrail.jsx
+++ b/src/Components/SpecificTrail.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { getSpecificTrail } from '../Modules/trailsData'
 import { Container, Grid, Header, Divider, Image } from 'semantic-ui-react'
+import { Map, GoogleApiWrapper, Marker } from 'google-maps-react'
 
 class SpecificTrail extends Component {
   state = {
@@ -26,8 +27,40 @@ class SpecificTrail extends Component {
   }
 
   render() {
-    let singleTrail, backButton
+    let singleTrail, backButton, trailMap
     const trail = this.state.trail
+    const style = {
+      width: '80%',
+      height: '80%',
+      left: '10%',
+      borderRadius: '8px'
+    }
+
+    if (trail) {
+      trailMap = (
+        <>
+          <Map 
+            google={this.props.google} 
+            zoom={5}
+            style={style}
+            center={{
+              lat: trail.latitude,
+              lng: trail.longitude
+            }}
+          >
+            <Marker
+              id={`trail_${trail.id}`}
+              key={trail.id}
+              title={trail.title}
+              position={{
+                lat: trail.latitude, 
+                lng: trail.longitude
+              }}
+            />
+          </Map>
+        </>
+      )
+    }
 
     if (trail) {
       singleTrail = (
@@ -83,6 +116,7 @@ class SpecificTrail extends Component {
 
     return (
       <>
+        {trailMap}
         {singleTrail}
         {backButton}
       </>
@@ -90,4 +124,6 @@ class SpecificTrail extends Component {
   }
 }
 
-export default SpecificTrail
+export default GoogleApiWrapper({
+  apiKey:(process.env.REACT_APP_API_KEY)
+})(SpecificTrail)

--- a/src/Components/SpecificTrail.jsx
+++ b/src/Components/SpecificTrail.jsx
@@ -31,9 +31,9 @@ class SpecificTrail extends Component {
     const trail = this.state.trail
     const style = {
       width: '80%',
-      height: '80%',
+      height: '50%',
       left: '10%',
-      borderRadius: '8px'
+      borderRadius: '8px'    
     }
 
     if (trail) {
@@ -41,9 +41,9 @@ class SpecificTrail extends Component {
         <>
           <Map 
             google={this.props.google} 
-            zoom={5}
+            zoom={13}
             style={style}
-            center={{
+            initialCenter={{
               lat: trail.latitude,
               lng: trail.longitude
             }}
@@ -69,14 +69,14 @@ class SpecificTrail extends Component {
             <Grid columns={2}>
               <Grid.Row>
                 <Grid.Column width={5}>
-                <Image
-                  id={`image_${trail.id}`}
-                  src={trail.image}
-                />
+                  <Image
+                    id={`image_${trail.id}`}
+                    src={trail.image}
+                  />
                 </Grid.Column>
-              <Grid.Column>
-                <Header as='h2' id={`title_${trail.id}`}>{trail.title}</Header>
-                <Divider />
+                <Grid.Column>
+                  <Header as='h2' id={`title_${trail.id}`}>{trail.title}</Header>
+                  <Divider />
                   <p className='single-description' id={`description_${trail.id}`}>{trail.description}</p>
                   <div className='single-trail'>
                     <h3>Good to know:</h3>
@@ -98,7 +98,7 @@ class SpecificTrail extends Component {
                     <h3>Intensity Level:</h3>
                     <p className='single-content' id={`intensity_${trail.id}`}>{trail.intensity}</p>
                   </div>
-              </Grid.Column>
+                </Grid.Column>
               </Grid.Row>
             </Grid>
           </Container>
@@ -116,9 +116,9 @@ class SpecificTrail extends Component {
 
     return (
       <>
-        {trailMap}
         {singleTrail}
         {backButton}
+        {trailMap}
       </>
     )
   }


### PR DESCRIPTION
[PT-Link](https://www.pivotaltracker.com/story/show/169801515)

## This PR Contains
```
As a user
In order to access all info about a specific trail on the same page
I need a map on the specific trail page displaying a marker with only that trail
```

## PR Content
- Map on specific Trail
- Modifies integration test
- Modifies fixture file

![Screenshot from 2019-11-19 20-00-21](https://user-images.githubusercontent.com/53904183/69177133-42b42400-0b07-11ea-9360-6a4e8962d69e.png)
