### PR TITLE
User is redirected to landing page on routes requiring sign in if already logged in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react'
-import { Route, Router } from 'react-router-dom'
+import { Route, Router, Redirect } from 'react-router-dom'
 import { createBrowserHistory } from 'history'
 import { connect } from 'react-redux'
-import { generateRequireSignInWrapper } from 'redux-token-auth'
+// import { generateRequireSignInWrapper } from 'redux-token-auth'
 import LandingPage from './Components/LandingPage'
 import SpecificTrail from './Components/SpecificTrail'
 import CreateTrail from './Components/CreateTrail'
@@ -17,10 +17,6 @@ import axios from 'axios'
 import getCurrentCredentials from './Modules/credentials'
 import ContinentResults from './Components/ContinentResults'
 
-const requireSignIn = generateRequireSignInWrapper({
-  redirectPathIfNotSignedIn: '/login'
-})
-
 const history = createBrowserHistory({})
 
 const App = ({ currentUser }) => {
@@ -32,16 +28,16 @@ const App = ({ currentUser }) => {
     <Router history={history}>
       <>
         <Navbar />
-        <Route exact path='/' component={LandingPage} />
-        <Route exact path='/trails/:id' component={SpecificTrail} />
-        <Route exact path='/create' component={requireSignIn(CreateTrail)} />
-        <Route exact path='/search' component={SearchResults} />
-        <Route exact path='/login' component={Login} />
+        <Route exact path='/' component={LandingPage}/>
+        <Route exact path='/trails/:id' component={SpecificTrail}/>
+        {currentUser.isSignedIn ? <Route exact path='/create' component={CreateTrail}/> : <Redirect to='/'/>}
+        <Route exact path='/search' component={SearchResults}/>
+        <Route exact path='/login' component={Login}/>
         <Route exact path='/signup' component={SignUp}/>
         <Route exact path='/map' component={MapContainer}/>
-        <Route exact path='/user/:name' component={requireSignIn(ProfilePage)}/>
+        {currentUser.isSignedIn ? <Route exact path='/user/:name' component={ProfilePage}/> : <Redirect to='/'/>}
         <Route exact path='/about' component={AboutUs}/>
-        <Route exact path='/continent' component={ContinentResults} />
+        <Route exact path='/continent' component={ContinentResults}/>
       </>
     </Router>
   )


### PR DESCRIPTION
[PT-Link](https://www.pivotaltracker.com/story/show/169891616)

## This PR Contains
```
As a user that is already logged in
In order to not have a blank page when refreshing on pages that requre sign in
I would like to be redirected to the landing page instead
```

## PR Content
- Removal of signInWrapper
- Adds ternary operator in Router for redirecting non logged in user on create / profile
- User is redirected to landing page when refreshing on restricted pages